### PR TITLE
Add connection with Opentheso too PACTOLS of FRANTIQ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /language/debug.po
 /language/debug.mo
 .php_cs.cache
+/nbproject/private/

--- a/README.md
+++ b/README.md
@@ -12,21 +12,17 @@ See general end user documentation for [Installing a module](http://omeka.org/s/
 
 This module includes the following vocabularies:
 
-- PACTOLS
 - GeoNames
 - The Getty Vocabularies
 - Homosaurus
 - Library of Congress Linked Data Service
 - OCLC Metadata Services
+- PACTOLS
 - PeriodO
 - RDA Value Vocabularies
 - Tesauros del patrimonio cultural de España
 - UNESCO
 
-
-## [Opentheso](http://pactols.frantiq.fr/)
-
-- The Pactols thesaurus
 
 ### [GeoNames](http://www.geonames.org/)
 
@@ -67,6 +63,10 @@ This module includes the following vocabularies:
 
 - Faceted Application of Subject Terminologies (FAST)
 - The Virtual International Authority File (VIAF)
+
+## [Opentheso](http://pactols.frantiq.fr/)
+
+- The Pactols thesaurus
 
 ### [PeriodO](http://perio.do/en/)
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ See general end user documentation for [Installing a module](http://omeka.org/s/
 
 This module includes the following vocabularies:
 
+- PACTOLS
 - GeoNames
 - The Getty Vocabularies
 - Homosaurus
@@ -21,6 +22,11 @@ This module includes the following vocabularies:
 - RDA Value Vocabularies
 - Tesauros del patrimonio cultural de España
 - UNESCO
+
+
+## [Opentheso](http://pactols.frantiq.fr/)
+
+- The Pactols thesaurus
 
 ### [GeoNames](http://www.geonames.org/)
 

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -22,8 +22,15 @@ return [
     ],
     'data_types' => [
         'factories' => [
+            
+            /* Opentheso / Pactols */
+            'valuesuggest:pactols:all' => 'ValueSuggest\Service\PactolsDataTypeFactory',
+            'valuesuggest:pactols:sujets' => 'ValueSuggest\Service\PactolsDataTypeFactory',   
+            
             /* Geonames */
             'valuesuggest:geonames:geonames' => 'ValueSuggest\Service\GeonamesDataTypeFactory',
+            
+          
 
             /* Getty */
             'valuesuggest:getty:aat' => 'ValueSuggest\Service\GettyDataTypeFactory',

--- a/src/DataType/Pactols/All.php
+++ b/src/DataType/Pactols/All.php
@@ -1,0 +1,24 @@
+<?php
+namespace ValueSuggest\DataType\Pactols;
+
+use ValueSuggest\DataType\AbstractDataType;
+use ValueSuggest\Suggester\Pactols\PactolsAll;
+
+class All extends AbstractDataType
+{
+    public function getSuggester()
+    {
+        return new PactolsAll($this->services->get('Omeka\HttpClient'));
+    }
+
+    public function getName()
+    {
+        return 'valuesuggest:pactols:all';
+    }
+
+    public function getLabel()
+    {
+        return 'Pactols: All thesaurus'; // @translate
+    }
+}
+

--- a/src/DataType/Pactols/Sujets.php
+++ b/src/DataType/Pactols/Sujets.php
@@ -1,0 +1,24 @@
+<?php
+namespace ValueSuggest\DataType\Pactols;
+
+use ValueSuggest\DataType\AbstractDataType;
+use ValueSuggest\Suggester\Pactols\PactolsSujets;
+
+class Sujets extends AbstractDataType
+{
+    public function getSuggester()
+    {
+        return new PactolsSujets($this->services->get('Omeka\HttpClient'));
+    }
+
+    public function getName()
+    {
+        return 'valuesuggest:pactols:sujets';
+    }
+
+    public function getLabel()
+    {
+        return 'Pactols: Sujets (Subject)'; // @translate
+    }
+}
+

--- a/src/Service/PactolsDataTypeFactory.php
+++ b/src/Service/PactolsDataTypeFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ValueSuggest\Service;
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Factory\FactoryInterface;
+
+class PactolsDataTypeFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
+    {
+        $name = ucfirst(strtolower(substr($requestedName, strrpos($requestedName, ':') + 1)));
+        $dataType = sprintf('ValueSuggest\DataType\Pactols\%s', $name);
+        return new $dataType($services);
+    }
+}
+

--- a/src/Suggester/Pactols/PactolsAll.php
+++ b/src/Suggester/Pactols/PactolsAll.php
@@ -49,7 +49,7 @@ class PactolsAll implements SuggesterInterface
             for($j=0; $j<sizeof($results[$i]["http://www.w3.org/2004/02/skos/core#prefLabel"]); $j++){
 
 
-                    if(strcasecmp(trim($results[$i]["http://www.w3.org/2004/02/skos/core#prefLabel"][$j]['@language']),'fr')==0){
+                    if(strcasecmp(trim($results[$i]["http://www.w3.org/2004/02/skos/core#prefLabel"][$j]['@language']),$lang)==0){
                             $valueLang=$results[$i]["http://www.w3.org/2004/02/skos/core#prefLabel"][$j]['@value'];
 
                             $suggestions[] = [

--- a/src/Suggester/Pactols/PactolsAll.php
+++ b/src/Suggester/Pactols/PactolsAll.php
@@ -24,14 +24,19 @@ class PactolsAll implements SuggesterInterface
      * @return array
      */
     public function getSuggestions($query, $lang = null)
-    {			
+    {
+        $params = ['q' => $query, 'theso' => 'TH_1', 'format' => 'jsonld'];
+        if ($lang) {
+            // Pactols requires an ISO-639 2-letter language code. Remove the
+            // first underscore and anything after it ("zh_CN" becomes "zh").
+            $params['lang'] = strstr($lang, '_', true) ?: $lang;
+        }
         $response = $this->client
 	->setUri('https://pactols.frantiq.fr/opentheso/api/search')
-        ->setParameterGet(['q' => $query, 'lang' =>'fr', 'theso' => 'TH_1', 'format' => 'jsonld'])
+        ->setParameterGet($params)
         ->send();
 		
         if (!$response->isSuccess()) {
-			file_put_contents($file,"return null",FILE_APPEND | LOCK_EX);
             return [];
         }
 		

--- a/src/Suggester/Pactols/PactolsAll.php
+++ b/src/Suggester/Pactols/PactolsAll.php
@@ -25,17 +25,16 @@ class PactolsAll implements SuggesterInterface
      */
     public function getSuggestions($query, $lang = null)
     {
+        $lang1 = 'fr' ?: $lang; // set french as the default language
+        $params['lang'] = $lang1;         
+        
         $params = ['q' => $query, 'theso' => 'TH_1', 'format' => 'jsonld'];
-        if ($lang) {
-            // Pactols requires an ISO-639 2-letter language code. Remove the
-            // first underscore and anything after it ("zh_CN" becomes "zh").
-            $params['lang'] = strstr($lang, '_', true) ?: $lang;
-        }
+
         $response = $this->client
 	->setUri('https://pactols.frantiq.fr/opentheso/api/search')
         ->setParameterGet($params)
         ->send();
-		
+        
         if (!$response->isSuccess()) {
             return [];
         }
@@ -49,7 +48,7 @@ class PactolsAll implements SuggesterInterface
             for($j=0; $j<sizeof($results[$i]["http://www.w3.org/2004/02/skos/core#prefLabel"]); $j++){
 
 
-                    if(strcasecmp(trim($results[$i]["http://www.w3.org/2004/02/skos/core#prefLabel"][$j]['@language']),$lang)==0){
+                    if(strcasecmp(trim($results[$i]["http://www.w3.org/2004/02/skos/core#prefLabel"][$j]['@language']),$lang1)==0){
                             $valueLang=$results[$i]["http://www.w3.org/2004/02/skos/core#prefLabel"][$j]['@value'];
 
                             $suggestions[] = [

--- a/src/Suggester/Pactols/PactolsAll.php
+++ b/src/Suggester/Pactols/PactolsAll.php
@@ -1,0 +1,65 @@
+<?php
+namespace ValueSuggest\Suggester\Pactols;
+
+use ValueSuggest\Suggester\SuggesterInterface;
+use Zend\Http\Client;
+
+class PactolsAll implements SuggesterInterface
+{
+    /**
+     * @var Clientx
+     */
+    protected $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Retrieve suggestions from the Opentheso 
+     *
+     *
+     * @param string $query
+     * @return array
+     */
+    public function getSuggestions($query, $lang = null)
+    {			
+        $response = $this->client
+	->setUri('https://pactols.frantiq.fr/opentheso/api/search')
+        ->setParameterGet(['q' => $query, 'lang' =>'fr', 'theso' => 'TH_1', 'format' => 'jsonld'])
+        ->send();
+		
+        if (!$response->isSuccess()) {
+			file_put_contents($file,"return null",FILE_APPEND | LOCK_EX);
+            return [];
+        }
+		
+        // Parse the JSON response.
+        $suggestions = [];
+        $results = json_decode($response->getBody(),true);
+		
+        for($i=0;$i<sizeof($results);$i++) {
+            $valueLang="";
+            for($j=0; $j<sizeof($results[$i]["http://www.w3.org/2004/02/skos/core#prefLabel"]); $j++){
+
+
+                    if(strcasecmp(trim($results[$i]["http://www.w3.org/2004/02/skos/core#prefLabel"][$j]['@language']),'fr')==0){
+                            $valueLang=$results[$i]["http://www.w3.org/2004/02/skos/core#prefLabel"][$j]['@value'];
+
+                            $suggestions[] = [
+                                    'value' =>$valueLang,
+                                    'data' => [
+                                            'uri' => sprintf('%s', $results[$i]['@id']),
+                                            'info' =>sprintf('%s', $results[$i]['@type'][0]),
+                                    ],
+                            ];
+
+                    }
+            }
+	}
+           return $suggestions;
+    }
+}
+
+

--- a/src/Suggester/Pactols/PactolsSujets.php
+++ b/src/Suggester/Pactols/PactolsSujets.php
@@ -25,13 +25,18 @@ class PactolsSujets implements SuggesterInterface
      */
     public function getSuggestions($query, $lang = null)
     {			
+        $params = ['q' => $query, 'theso' => 'TH_1', 'group' => '6', 'format' => 'jsonld'];
+        if ($lang) {
+            // Pactols requires an ISO-639 2-letter language code. Remove the
+            // first underscore and anything after it ("zh_CN" becomes "zh").
+            $params['lang'] = strstr($lang, '_', true) ?: $lang;
+        }
         $response = $this->client
 	->setUri('https://pactols.frantiq.fr/opentheso/api/search')
-        ->setParameterGet(['q' => $query, 'lang' =>'fr', 'theso' => 'TH_1', 'group' => '6', 'format' => 'jsonld'])
+        ->setParameterGet($params)
         ->send();
 		
         if (!$response->isSuccess()) {
-			file_put_contents($file,"return null",FILE_APPEND | LOCK_EX);
             return [];
         }
 		

--- a/src/Suggester/Pactols/PactolsSujets.php
+++ b/src/Suggester/Pactols/PactolsSujets.php
@@ -1,0 +1,65 @@
+<?php
+namespace ValueSuggest\Suggester\Pactols;
+
+use ValueSuggest\Suggester\SuggesterInterface;
+use Zend\Http\Client;
+
+class PactolsSujets implements SuggesterInterface
+{
+    /**
+     * @var Clientx
+     */
+    protected $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Retrieve suggestions from the Opentheso 
+     *
+     *
+     * @param string $query
+     * @return array
+     */
+    public function getSuggestions($query, $lang = null)
+    {			
+        $response = $this->client
+	->setUri('https://pactols.frantiq.fr/opentheso/api/search')
+        ->setParameterGet(['q' => $query, 'lang' =>'fr', 'theso' => 'TH_1', 'group' => '6', 'format' => 'jsonld'])
+        ->send();
+		
+        if (!$response->isSuccess()) {
+			file_put_contents($file,"return null",FILE_APPEND | LOCK_EX);
+            return [];
+        }
+		
+        // Parse the JSON response.
+        $suggestions = [];
+        $results = json_decode($response->getBody(),true);
+		
+        for($i=0;$i<sizeof($results);$i++) {
+            $valueLang="";
+            for($j=0; $j<sizeof($results[$i]["http://www.w3.org/2004/02/skos/core#prefLabel"]); $j++){
+
+
+                    if(strcasecmp(trim($results[$i]["http://www.w3.org/2004/02/skos/core#prefLabel"][$j]['@language']),'fr')==0){
+                            $valueLang=$results[$i]["http://www.w3.org/2004/02/skos/core#prefLabel"][$j]['@value'];
+
+                            $suggestions[] = [
+                                    'value' =>$valueLang,
+                                    'data' => [
+                                            'uri' => sprintf('%s', $results[$i]['@id']),
+                                            'info' =>sprintf('%s', $results[$i]['@type'][0]),
+                                    ],
+                            ];
+
+                    }
+            }
+	}
+           return $suggestions;
+    }
+}
+
+

--- a/src/Suggester/Pactols/PactolsSujets.php
+++ b/src/Suggester/Pactols/PactolsSujets.php
@@ -24,13 +24,12 @@ class PactolsSujets implements SuggesterInterface
      * @return array
      */
     public function getSuggestions($query, $lang = null)
-    {			
-        $params = ['q' => $query, 'theso' => 'TH_1', 'group' => '6', 'format' => 'jsonld'];
-        if ($lang) {
-            // Pactols requires an ISO-639 2-letter language code. Remove the
-            // first underscore and anything after it ("zh_CN" becomes "zh").
-            $params['lang'] = strstr($lang, '_', true) ?: $lang;
-        }
+    {		
+        $lang1 = 'fr' ?: $lang; // set french as the default language
+        $params['lang'] = $lang1; 
+     
+        $params = ['q' => $query, 'theso' => 'TH_1',  'group' => '6', 'format' => 'jsonld'];
+        
         $response = $this->client
 	->setUri('https://pactols.frantiq.fr/opentheso/api/search')
         ->setParameterGet($params)
@@ -49,7 +48,7 @@ class PactolsSujets implements SuggesterInterface
             for($j=0; $j<sizeof($results[$i]["http://www.w3.org/2004/02/skos/core#prefLabel"]); $j++){
 
 
-                    if(strcasecmp(trim($results[$i]["http://www.w3.org/2004/02/skos/core#prefLabel"][$j]['@language']),$lang)==0){
+                    if(strcasecmp(trim($results[$i]["http://www.w3.org/2004/02/skos/core#prefLabel"][$j]['@language']),$lang1)==0){
                             $valueLang=$results[$i]["http://www.w3.org/2004/02/skos/core#prefLabel"][$j]['@value'];
 
                             $suggestions[] = [

--- a/src/Suggester/Pactols/PactolsSujets.php
+++ b/src/Suggester/Pactols/PactolsSujets.php
@@ -49,7 +49,7 @@ class PactolsSujets implements SuggesterInterface
             for($j=0; $j<sizeof($results[$i]["http://www.w3.org/2004/02/skos/core#prefLabel"]); $j++){
 
 
-                    if(strcasecmp(trim($results[$i]["http://www.w3.org/2004/02/skos/core#prefLabel"][$j]['@language']),'fr')==0){
+                    if(strcasecmp(trim($results[$i]["http://www.w3.org/2004/02/skos/core#prefLabel"][$j]['@language']),$lang)==0){
                             $valueLang=$results[$i]["http://www.w3.org/2004/02/skos/core#prefLabel"][$j]['@value'];
 
                             $suggestions[] = [


### PR DESCRIPTION
Hi, 
I would like you to add a new connection source in ValueSuggest for the thesaurus specialized in archeology "[PACTOLS](https://pactols.frantiq.fr/opentheso)" of the grouping services [Frantiq](https://www.frantiq.fr). This connection is based on the thesaurus management software "[Opentheso](https://github.com/miledrousset/opentheso)" using its webservices. This source is requested by many projects.
Thank you