### PR TITLE
Allowed to use a vocabulary without uri.

### DIFF
--- a/asset/js/valuesuggest.js
+++ b/asset/js/valuesuggest.js
@@ -105,16 +105,26 @@ $(document).on('o:prepare-value', function(e, type, value) {
                 // Set value as URI type
                 suggestInput.val(suggestion.value)
                     .attr('placeholder', suggestion.value);
-                idInput.val(suggestion.data.uri);
-                labelInput.val(suggestion.value);
-                idInput.prop('disabled', false);
-                labelInput.prop('disabled', false);
-                valueInput.prop('disabled', true);
-                var link = $('<a>')
-                    .attr('href', suggestion.data.uri)
-                    .attr('target', '_blank')
-                    .text(suggestion.data.uri);
-                idContainer.show().find('.valuesuggest-id').html(link);
+                if (suggestion.data.uri) {
+                    idInput.val(suggestion.data.uri);
+                    labelInput.val(suggestion.value);
+                    idInput.prop('disabled', false);
+                    labelInput.prop('disabled', false);
+                    valueInput.prop('disabled', true);
+                    var link = $('<a>')
+                        .attr('href', suggestion.data.uri)
+                        .attr('target', '_blank')
+                        .text(suggestion.data.uri);
+                    idContainer.show().find('.valuesuggest-id').html(link);
+                } else {
+                    idInput.val('');
+                    labelInput.val('');
+                    valueInput.val(suggestion.value);
+                    idInput.prop('disabled', true);
+                    labelInput.prop('disabled', true);
+                    valueInput.prop('disabled', false);
+                    idContainer.hide();
+                }
             }
         };
 


### PR DESCRIPTION
This allows to convert automatically into a "literal" (#38) so it's possible to use an endpoint for a simple authority list like custom vocab.