### PR TITLE
Made accessible the suggest info when available.

### DIFF
--- a/asset/css/valuesuggest.css
+++ b/asset/css/valuesuggest.css
@@ -5,6 +5,13 @@
 .autocomplete-group { padding: 2px 5px; }
 .autocomplete-group strong { display: block; border-bottom: 1px solid #000; }
 
+.autocomplete-suggestion.autocomplete-selected {
+    background-color: #e5e5e5;
+}
+.autocomplete-suggestion .suggest-info {
+    color: #666666;
+}
+
 .valuesuggest-language-container,
 .valuesuggest-vocab-container {
     position: relative;

--- a/asset/js/valuesuggest.js
+++ b/asset/js/valuesuggest.js
@@ -125,9 +125,12 @@ $(document).on('o:prepare-value', function(e, type, value) {
             options.minChars = 0;
             // Prepare the suggestions prior to rendering them.
             options.beforeRender = function(container, suggestions) {
-                // Add title attribute to each suggestion for disambiguation.
+                // Add available info to each suggestion for disambiguation.
                 container.children().each(function(index) {
-                    $(this).attr('title', suggestions[index].data.info);
+                    if (suggestions[index].data.info) {
+                        $(this).append('<div class="suggest-info"></div>')
+                            .find('.suggest-info').append(suggestions[index].data.info);
+                    }
                 });
                 // Hide suggestions that contain no matches.
                 var hasSuggestions = container.children(':has(strong)');
@@ -158,9 +161,12 @@ $(document).on('o:prepare-value', function(e, type, value) {
             options.preventBadQueries = false;
             // Prepare the suggestions prior to rendering them.
             options.beforeRender = function(container, suggestions) {
-                // Add title attribute to each suggestion for disambiguation.
+                // Add available info to each suggestion for disambiguation.
                 container.children().each(function(index) {
-                    $(this).attr('title', suggestions[index].data.info);
+                    if (suggestions[index].data.info) {
+                        $(this).append('<div class="suggest-info"></div>')
+                            .find('.suggest-info').append(suggestions[index].data.info);
+                    }
                 });
             };
         }


### PR DESCRIPTION
Maybe some css to add to get long info on two or three lines instead of a truncated one (see #43).