### PR TITLE
NDE: RKD: Use 'OPTIMIZED' query mode

### DIFF
--- a/src/Suggester/NdeTerms/NdeTermsSuggest.php
+++ b/src/Suggester/NdeTerms/NdeTermsSuggest.php
@@ -64,7 +64,8 @@ class NdeTermsSuggest implements SuggesterInterface
 query FindTerm {
     terms(
         sources: ["$source"],
-        query: "$searchPhrase")
+        query: "$searchPhrase",
+        queryMode: OPTIMIZED)
     {
         source {
             name


### PR DESCRIPTION
As introduced in netwerk-digitaal-erfgoed/network-of-terms#398

In particular this makes searching for words with diacritical marks in Virtuoso-backed sources work, such as searching for 'Miró' in the RKD artists database.