### PR TITLE
NDE: Add Getty AAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This module includes the following vocabularies:
 ### [Dutch Digital Heritage Network of Terms: NDE Termennetwerk](https://termennetwerk.netwerkdigitaalerfgoed.nl/)
 
 - Archeologisch Basisregister
+- Art & Architecture Thesaurus
 - Brinkman trefwoordenthesaurus
 - Cultuurhistorische Thesaurus
 - GTAA: genres

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -85,6 +85,7 @@ return [
             // @todo Add more LC data types
 
             /* Network of Terms of the Dutch National Network for Digital Heritage */
+            'valuesuggest:ndeterms:aat' => \ValueSuggest\Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:abr' => \ValueSuggest\Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:btt' => \ValueSuggest\Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:cht' => \ValueSuggest\Service\NdeTermsDataTypeFactory::class,

--- a/src/Service/NdeTermsDataTypeFactory.php
+++ b/src/Service/NdeTermsDataTypeFactory.php
@@ -12,6 +12,10 @@ use ValueSuggest\DataType\NdeTerms\NdeTerms;
 class NdeTermsDataTypeFactory implements FactoryInterface
 {
     protected $types = [
+        'valuesuggest:ndeterms:aat' => [
+            'label' => 'NDE: Art & Architecture Thesaurus', // @translate
+            'source' => 'http://vocab.getty.edu/aat/sparql',
+        ],
         'valuesuggest:ndeterms:abr' => [
             'label' => 'NDE: Archeologisch Basisregister', // @translate
             'source' => 'https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/abr',


### PR DESCRIPTION
This may seems like a duplicate of the 'direct' Getty AAT value suggest source, but by looking up the values through the NDE we get Dutch labels.

Of course even longer time it would be cool if we could support entirely i18n'ed labels from a single source, but that's rather more complicated (and might first require changes to the generic Omeka S data model? not sure)