### PR TITLE
Fix suggester for IdRef: Rameau

### DIFF
--- a/src/Service/IdRefDataTypeFactory.php
+++ b/src/Service/IdRefDataTypeFactory.php
@@ -32,7 +32,7 @@ class IdRefDataTypeFactory implements FactoryInterface
         ],
         'valuesuggest:idref:rameau' => [
             'label' => 'IdRef: Subjects Rameau', // @translate
-            'url' => 'https://www.idref.fr/Sru/Solr?wt=json&version=2.2&start=&rows=30&indent=on&fl=id,ppn_z,affcourt_z&q=recordtype_z%3Ar%20AND%20subjectheading_t%3A',
+            'url' => 'https://www.idref.fr/Sru/Solr?wt=json&version=2.2&start=&rows=30&indent=on&fl=id,ppn_z,affcourt_z&q=recordtype_z%3A%28u%20OR%20v%29%20AND%20formgenreheading_t%3A',
         ],
         'valuesuggest:idref:fmesh' => [
             'label' => 'IdRef: Subjects F-MeSH', // @translate


### PR DESCRIPTION
Something changed in the Solr backend that caused queries to never return any results.

Changing `recordtype_z:r` (Rameau) to `recordtype_z:(u OR v)` (Rameau form OR Rameau genre) fix the issue.

Also change the search index from `subjectheading_t` to `formgenreheading_t` which is more adequate according to https://documentation.abes.fr/aideidrefdeveloppeur/index.html#index