### PR TITLE
Fix suggester for IdRef: Rameau (again)

### DIFF
--- a/src/Service/IdRefDataTypeFactory.php
+++ b/src/Service/IdRefDataTypeFactory.php
@@ -32,7 +32,7 @@ class IdRefDataTypeFactory implements FactoryInterface
         ],
         'valuesuggest:idref:rameau' => [
             'label' => 'IdRef: Subjects Rameau', // @translate
-            'url' => 'https://www.idref.fr/Sru/Solr?wt=json&version=2.2&start=&rows=30&indent=on&fl=id,ppn_z,affcourt_z&q=recordtype_z%3Ar%20AND%20subjectheading_t%3A',
+            'url' => 'https://www.idref.fr/Sru/Solr?wt=json&version=2.2&start=&rows=30&indent=on&fl=id,ppn_z,affcourt_z&q=recordtype_z%3Aj%20AND%20subjectheading_t%3A',
         ],
         'valuesuggest:idref:fmesh' => [
             'label' => 'IdRef: Subjects F-MeSH', // @translate

--- a/src/Service/IdRefDataTypeFactory.php
+++ b/src/Service/IdRefDataTypeFactory.php
@@ -32,7 +32,7 @@ class IdRefDataTypeFactory implements FactoryInterface
         ],
         'valuesuggest:idref:rameau' => [
             'label' => 'IdRef: Subjects Rameau', // @translate
-            'url' => 'https://www.idref.fr/Sru/Solr?wt=json&version=2.2&start=&rows=30&indent=on&fl=id,ppn_z,affcourt_z&q=recordtype_z%3A%28u%20OR%20v%29%20AND%20formgenreheading_t%3A',
+            'url' => 'https://www.idref.fr/Sru/Solr?wt=json&version=2.2&start=&rows=30&indent=on&fl=id,ppn_z,affcourt_z&q=recordtype_z%3Ar%20AND%20subjectheading_t%3A',
         ],
         'valuesuggest:idref:fmesh' => [
             'label' => 'IdRef: Subjects F-MeSH', // @translate


### PR DESCRIPTION
The previous fix was wrong ("Rameau form OR Rameau genre" is not the same thing as "Rameau")

The only thing that changed on the Solr backend is the value of `recordtype_z` for Rameau records: it was `r` and is now `j`

This is currently not documented anywhere but it has been confirmed by a maintainer of the web service.

See: https://github.com/abes-esr/abes-webservices/issues/7 [fr]