### PR TITLE
Use correct URI values in ViafSuggest

### DIFF
--- a/src/Suggester/Oclc/ViafSuggest.php
+++ b/src/Suggester/Oclc/ViafSuggest.php
@@ -41,7 +41,7 @@ class ViafSuggest implements SuggesterInterface
             $suggestions[] = [
                 'value' => $result['term'],
                 'data' => [
-                    'uri' => sprintf('http://www.viaf.org/viaf/%s', $result['viafid']),
+                    'uri' => sprintf('http://viaf.org/viaf/%s', $result['viafid']),
                     'info' => null,
                 ],
             ];


### PR DESCRIPTION
Viaf URIs are in the form of `http://viaf.org/viaf/17252502` whereas the ValueSuggest module currently uses `http://www.viaf.org/viaf/17252502`. Note the "www" in front of the toplevel viaf domain.

This leads to problems in applications that use linked data provided by Omeka S, since Viaf URIs coming from Omeka S cannot be matched with Viaf URIs coming from other sources.

This pull request contains a fix and makes sure that the Viaf URI value is in the correct form for all **new items** added.


In order to retrospectively change the Viaf URI values for **existing items** in Omeka S, one could use the following SQL UPDATE statement.
```
UPDATE value
SET uri = REPLACE(uri, 'www.viaf.org', 'viaf.org')
WHERE uri LIKE '%www.viaf.org%';
```


Best regards,
Maarten Coonen
Data Engineer & Developer at Maastricht University Library