### PR TITLE
Fixed ViafSuggest compatibility (HTTPS, cURL, Accept-Encoding)

### DIFF
--- a/config/module.ini
+++ b/config/module.ini
@@ -1,5 +1,5 @@
 [info]
-version = "1.17.1"
+version = "1.17.2"
 omeka_version_constraint = "^4.0.0"
 name = "Value Suggest"
 description = "Describe your resources using auto-suggested values from controlled vocabulary services."

--- a/src/Suggester/Oclc/ViafSuggest.php
+++ b/src/Suggester/Oclc/ViafSuggest.php
@@ -52,11 +52,19 @@ class ViafSuggest implements SuggesterInterface
         $suggestions = [];
         $results = json_decode($response->getBody(), true);
         foreach ($results['result'] as $result) {
+            $info = [];
+            if ($result['nametype']) {
+                $info[] = sprintf('Type: %s', $result['nametype']);
+            }
+            if ($result['viafid']) {
+                $info[] = sprintf('VIAF ID: %s', $result['viafid']);
+            }
+
             $suggestions[] = [
                 'value' => $result['term'],
                 'data' => [
                     'uri' => sprintf('http://viaf.org/viaf/%s', $result['viafid']),
-                    'info' => null,
+                    'info' => implode("\n", $info),
                 ],
             ];
         }

--- a/src/Suggester/Oclc/ViafSuggest.php
+++ b/src/Suggester/Oclc/ViafSuggest.php
@@ -19,17 +19,31 @@ class ViafSuggest implements SuggesterInterface
     /**
      * Retrieve suggestions from the VIAF auto suggest service.
      *
-     * @see https://platform.worldcat.org/api-explorer/apis/VIAF
+     * @see https://developer.api.oclc.org/viaf-api
      * @param string $query
      * @param string $lang
      * @return array
      */
     public function getSuggestions($query, $lang = null)
     {
+        $params = [
+            'query' => $query,
+        ];
+
+        // The VIAF API is hosted on Cloudflare. The default Laminas\Http\Client\Adapter\Socket triggers a
+        // Cloudflare "security service that protect itself from online attacks", i.e. automated traffic.
+        // Let's use a fallback to the cURL adapter, as that is compatible with the Cloudflare hosted VIAF API.
         $response = $this->client
-            ->setUri('http://www.viaf.org/viaf/AutoSuggest')
-            ->setParameterGet(['query' => $query])
+            ->setAdapter('Laminas\Http\Client\Adapter\Curl')    // Fallback to cURL
+            ->setUri('https://www.viaf.org/viaf/AutoSuggest')
+            ->setHeaders([
+                // Override some default headers set by Laminas\Http\Client
+                'Accept-Encoding' => 'deflate, br, identity',   // 'gzip' is not supported
+                'Accept' => 'application/json',
+            ])
+            ->setParameterGet($params)
             ->send();
+
         if (!$response->isSuccess()) {
             return [];
         }


### PR DESCRIPTION
Several users were reporting in [this Omeka S forum post](https://forum.omeka.org/t/viaf-not-working-on-valuesuggest-module/26931) that the ValueSuggest functionality for VIAF stopped working. 

I have looked into the problem, created a fix and included it in this Pull Request. 
The fix consists of three parts:
1. Switch to HTTPS
2. Fallback to cURL adapter of Laminas\Http\Client to avoid getting flagged as automated traffic by the Cloudfare security service
3. Only request Accept-Encodings that are compatible.

Furthermore, I have also extended the functionality of the ViafSuggest by showing additional info when hovering over the suggestions when entering terms in the item metadata.

I hope to see this PR accepted and included in the next release of the ValueSuggest module soon. 
Best regards,
Maarten Coonen