### PR TITLE
Allow automatic updates of ValueSuggest values (IdRef only)

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -7,6 +7,27 @@ return [
             'ValueSuggest\Controller\Index' => Service\IndexControllerFactory::class,
         ],
     ],
+    'form_elements' => [
+        'factories' => [
+            Form\UpdateForm::class => Service\Form\UpdateFormFactory::class,
+        ],
+    ],
+    'navigation' => [
+        'AdminModule' => [
+            [
+                'label' => 'Value Suggest',
+                'route' => 'admin/value-suggest/update',
+                'resource' => 'ValueSuggest\Controller\Index',
+                'privilege' => 'update',
+                'pages' => [
+                    [
+                        'label' => 'Update values', // @translate
+                        'route' => 'admin/value-suggest/update',
+                    ],
+                ],
+            ],
+        ],
+    ],
     'translator' => [
         'translation_file_patterns' => [
             [
@@ -298,6 +319,15 @@ return [
                                     ],
                                 ],
                             ],
+                            'update' => [
+                                'type' => 'Literal',
+                                'options' => [
+                                    'route' => '/update',
+                                    'defaults' => [
+                                        'action' => 'update',
+                                    ],
+                                ],
+                            ]
                         ],
                     ],
                 ],

--- a/src/DataType/IdRef/IdRef.php
+++ b/src/DataType/IdRef/IdRef.php
@@ -2,9 +2,12 @@
 namespace ValueSuggest\DataType\IdRef;
 
 use ValueSuggest\DataType\AbstractDataType;
+use ValueSuggest\DataType\UpdatableDataTypeInterface;
 use ValueSuggest\Suggester\IdRef\IdRefSuggestAll;
+use ValueSuggest\Updater\IdRefUpdater;
+use ValueSuggest\Updater\UpdaterInterface;
 
-class Idref extends AbstractDataType
+class Idref extends AbstractDataType implements UpdatableDataTypeInterface
 {
     protected $idrefName;
     protected $idrefLabel;
@@ -34,6 +37,14 @@ class Idref extends AbstractDataType
             $this->services->get('Omeka\HttpClient'),
             $this->idrefUrl
         );
+    }
+
+    public function getUpdater(): UpdaterInterface
+    {
+        $httpClient = $this->services->get('Omeka\HttpClient');
+        $logger = $this->services->get('Omeka\Logger');
+
+        return new IdRefUpdater($httpClient, $logger);
     }
 
     public function getName()

--- a/src/DataType/UpdatableDataTypeInterface.php
+++ b/src/DataType/UpdatableDataTypeInterface.php
@@ -1,0 +1,12 @@
+<?php
+namespace ValueSuggest\DataType;
+
+use ValueSuggest\Updater\UpdaterInterface;
+
+interface UpdatableDataTypeInterface extends DataTypeInterface
+{
+    /**
+     * Get the updater needed to update values.
+     */
+    public function getUpdater(): UpdaterInterface;
+}

--- a/src/Form/UpdateForm.php
+++ b/src/Form/UpdateForm.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace ValueSuggest\Form;
+
+use Laminas\Form\Element\MultiCheckbox;
+use Laminas\Form\Form;
+use Omeka\DataType\Manager as DataTypeManager;
+use ValueSuggest\DataType\UpdatableDataTypeInterface;
+
+class UpdateForm extends Form
+{
+    protected DataTypeManager $dataTypeManager;
+
+    public function init()
+    {
+        $this->add([
+            'name' => 'data_types',
+            'type' => MultiCheckbox::class,
+            'options' => [
+                'label' => 'Data types to update', // @translate
+                'info' => 'Only values of selected data types will be updated. Selecting none have the same effect as selecting all.', // @translate
+                'value_options' => $this->getDataTypesValueOptions(),
+            ],
+        ]);
+
+        $inputFilter = $this->getInputFilter();
+
+        $inputFilter->add([
+            'name' => 'data_types',
+            'required' => false,
+        ]);
+    }
+
+    protected function getDataTypesValueOptions()
+    {
+        $dataTypeManager = $this->getDataTypeManager();
+
+        $valueOptions = [];
+
+        $names = $dataTypeManager->getRegisteredNames(true);
+        foreach ($names as $name) {
+            $dataType = $dataTypeManager->get($name);
+            if ($dataType instanceof UpdatableDataTypeInterface) {
+                $valueOptions[$dataType->getName()] = $dataType->getLabel();
+            }
+        }
+
+        return $valueOptions;
+    }
+
+    public function setDataTypeManager(DataTypeManager $dataTypeManager)
+    {
+        $this->dataTypeManager = $dataTypeManager;
+    }
+
+    public function getDataTypeManager(): DataTypeManager
+    {
+        return $this->dataTypeManager;
+    }
+}

--- a/src/Job/Update.php
+++ b/src/Job/Update.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace ValueSuggest\Job;
+
+use Omeka\Job\AbstractJob;
+use ValueSuggest\DataType\UpdatableDataTypeInterface;
+
+class Update extends AbstractJob
+{
+    const BATCH_SIZE = 100;
+
+    public function perform()
+    {
+        $serviceLocator = $this->getServiceLocator();
+        $logger = $serviceLocator->get('Omeka\Logger');
+        $em = $serviceLocator->get('Omeka\EntityManager');
+
+        $logger->info('Job started');
+        $em->flush();
+
+        $updatableDataTypes = $this->getUpdatableDataTypes();
+        $updatableDataTypeNames = array_keys($updatableDataTypes);
+
+        $dataTypeNames = $this->getArg('data_types', []);
+        if (empty($dataTypeNames)) {
+            $dataTypeNames = $updatableDataTypeNames;
+        } else {
+            $dataTypeNames = array_intersect($dataTypeNames, $updatableDataTypeNames);
+        }
+
+        $originalIdentityMap = $this->getEntityManager()->getUnitOfWork()->getIdentityMap();
+
+        $updatedCounts = [];
+        $updatedResourceIds = [];
+
+        foreach ($dataTypeNames as $dataTypeName) {
+            $dataType = $updatableDataTypes[$dataTypeName];
+            $logger->info(sprintf('Processing data type "%s"', $dataTypeName));
+            $em->flush();
+
+            $updatedCounts[$dataTypeName] = 0;
+
+            $updater = $dataType->getUpdater();
+            $lastId = 0;
+            $query = $em->createQuery('select v from Omeka\Entity\Value v where v.type = :type and v.id > :lastId order by v.id asc');
+            $query->setMaxResults(self::BATCH_SIZE);
+            $query->setParameter('type', $dataTypeName);
+            $query->setParameter('lastId', $lastId);
+            $values = $query->getResult();
+            $processedCount = 0;
+            while (!empty($values)) {
+                foreach ($values as $value) {
+                    $lastId = $value->getId();
+
+                    if ($updater->update($value)) {
+                        $updatedCounts[$dataTypeName]++;
+
+                        $resourceId = $value->getResource()->getId();
+                        $updatedResourceIds[$resourceId] = $resourceId;
+                    }
+
+                    $processedCount++;
+                }
+
+                $em->flush();
+                $this->detachAllNewEntities($originalIdentityMap);
+
+                $query->setParameter('lastId', $lastId);
+                $values = $query->getResult();
+            }
+
+            $logger->info(sprintf('Processed %d values (%d were updated)', $processedCount, $updatedCounts[$dataTypeName]));
+            $em->flush();
+        }
+
+        $logger->info(sprintf('Total values updated: %d (in %d resources)', array_sum($updatedCounts), count($updatedResourceIds)));
+
+        $logger->info('Job ended normally');
+    }
+
+    protected function getUpdatableDataTypes(): array
+    {
+        $serviceLocator = $this->getServiceLocator();
+        $dataTypeManager = $serviceLocator->get('Omeka\DataTypeManager');
+
+        $updatableDataTypes = [];
+
+        foreach ($dataTypeManager->getRegisteredNames(true) as $name) {
+            $dataType = $dataTypeManager->get($name);
+            if ($dataType instanceof UpdatableDataTypeInterface) {
+                $updatableDataTypes[$name] = $dataType;
+            }
+        }
+
+        return $updatableDataTypes;
+    }
+
+    protected function detachAllNewEntities(array $oldIdentityMap)
+    {
+        $entityManager = $this->getEntityManager();
+        $identityMap = $entityManager->getUnitOfWork()->getIdentityMap();
+        foreach ($identityMap as $entityClass => $entities) {
+            foreach ($entities as $idHash => $entity) {
+                if (!isset($oldIdentityMap[$entityClass][$idHash])) {
+                    $entityManager->detach($entity);
+                }
+            }
+        }
+    }
+
+    protected function getEntityManager()
+    {
+        return $this->getServiceLocator()->get('Omeka\EntityManager');
+    }
+}

--- a/src/Service/Form/UpdateFormFactory.php
+++ b/src/Service/Form/UpdateFormFactory.php
@@ -1,0 +1,19 @@
+<?php
+namespace ValueSuggest\Service\Form;
+
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use ValueSuggest\Form\UpdateForm;
+
+class UpdateFormFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
+    {
+        $dataTypeManager = $services->get('Omeka\DataTypeManager');
+
+        $form = new UpdateForm(null, $options ?? []);
+        $form->setDataTypeManager($dataTypeManager);
+
+        return $form;
+    }
+}

--- a/src/Updater/IdRefUpdater.php
+++ b/src/Updater/IdRefUpdater.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace ValueSuggest\Updater;
+
+use Laminas\Http\Client as HttpClient;
+use Laminas\Http\Request;
+use Laminas\Log\Logger;
+use Omeka\Entity\Value;
+
+class IdRefUpdater implements UpdaterInterface
+{
+    protected HttpClient $httpClient;
+    protected Logger $logger;
+
+    public function __construct(HttpClient $httpClient, Logger $logger)
+    {
+        $this->httpClient = $httpClient;
+        $this->logger = $logger;
+    }
+
+    public function update(Value $value): bool
+    {
+        $logger = $this->logger;
+
+        $uri = $value->getUri();
+        if (!$uri) {
+            $logger->warn(sprintf('IdRefUpdater: value does not have an URI (id: %d)', $value->getId()));
+            return false;
+        }
+
+        $matches = [];
+        if (!preg_match('~https?://www.idref.fr/([0-9X]{9})~', $uri, $matches)) {
+            $logger->warn(sprintf('IdRefUpdater: value URI does not match typical IdRef URI (id: %d, uri: %s)', $value->getId(), $uri));
+            return false;
+        }
+
+        $ppn = $matches[1];
+        $solrUri = sprintf('https://www.idref.fr/Sru/Solr?wt=json&fl=affcourt_z&q=ppn_z:%s', urlencode($ppn));
+        $request = new Request;
+        $request->setUri($solrUri);
+        $response = $this->httpClient->send($request);
+        if (!$response->isSuccess()) {
+            $logger->warn(sprintf('IdRefUpdater: request to IdRef failed (uri: %s, status code: %d)', $solrUri, $response->getStatusCode()));
+            return false;
+        }
+
+        $json = $response->getContent();
+        $data = json_decode($json, true);
+        if (!$data) {
+            $logger->warn(sprintf('IdRefUpdater: failed to parse response as JSON: %s', json_last_error_msg()));
+            return false;
+        }
+
+        $docs = $data['response']['docs'];
+        if (empty($docs)) {
+            $logger->warn(sprintf('IdRefUpdater: no record found for PPN "%s"', $ppn));
+            return false;
+        }
+
+        $label = $docs[0]['affcourt_z'];
+        if (!$label) {
+            $logger->warn(sprintf('IdRefUpdater: record found for PPN "%s" has no "affcourt_z"', $ppn));
+            return false;
+        }
+
+        if ($value->getValue() === $label) {
+            // Nothing to update, do not log anything as it is the most common case.
+            return false;
+        }
+
+        $logger->info(
+            sprintf(
+                'IdRefUpdater: value %d updated ("%s" -> "%s") for resource %d',
+                $value->getId(),
+                $value->getValue(),
+                $label,
+                $value->getResource()->getId()
+            )
+        );
+
+        $value->setValue($label);
+
+        return true;
+    }
+}

--- a/src/Updater/UpdaterInterface.php
+++ b/src/Updater/UpdaterInterface.php
@@ -1,0 +1,14 @@
+<?php
+namespace ValueSuggest\Updater;
+
+use Omeka\Entity\Value;
+
+interface UpdaterInterface
+{
+    /**
+     * Updates a value (if needed)
+     *
+     * @return bool true if $value was modified, false otherwise
+     */
+    public function update(Value $value): bool;
+}

--- a/view/value-suggest/index/update.phtml
+++ b/view/value-suggest/index/update.phtml
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @var \ValueSuggest\Form\UpdateForm $form
+ */
+?>
+
+<?= $this->pageTitle($this->translate('Update values'), 1, $this->translate('Value Suggest')) ?>
+
+<?php $form->prepare(); ?>
+<?= $this->form()->openTag($form) ?>
+
+<div id="page-actions">
+    <button type="submit"><?= $this->translate('Start update') ?></button>
+</div>
+
+<?= $this->formCollection($form) ?>
+<?= $this->form()->closeTag() ?>


### PR DESCRIPTION
Preamble: I'm not sure if this thing should go in ValueSuggest itself or in another module. If you think it's best done in a separate module, please tell me. I'll happily close that PR and do that instead.

----

Some suggesters returns a label and a URI. They are both stored in the database.  But it's possible that the label associated to that URI change over time, making the label in Omeka outdated.

This patch adds the ability for data types to declare an "updater" that will take care of retrieving up-to-date informations and updating the value accordingly.
This update process is accessible through a new item in the admin navigation menu.  It is possible to limit which data types should be checked and updated.
The update will be done in a background job.

This patch implements an updater for IdRef data types.

Test plan:
1. Create a resource template with dcterms:subject linked to data type "IdRef: Subjects"
2. Create an item with this resource template, and add a subject:
   - Start typing (for instance, "rome" will return several suggestions)
   - Select one of the suggestions
3. Once the suggester has filled the URI field, modify slightly the label (add or remove some characters) and save the item.
4. Click on "Value Suggest" in the admin sidebar
5. Check "IdRef: Subjects" checkbox and submit the form
6. Go to "Jobs", wait until the job is complete (it should not take more than a second)
7. Verify in your item that the value was correctly updated to its original value.